### PR TITLE
Fix bikeshed errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9,6 +9,7 @@ URL: https://wicg.github.io/user-preference-media-features-headers/
 Editor: Thomas Steiner, Google LLC https://google.com, tomac@google.com
 Editor: François Beaufort, Google LLC https://google.com, fbeaufort@google.com
 Abstract: HTTP Client Hints defines an <code>Accept-CH</code> response header that servers can use to advertise their use of request headers for proactive content negotiation. This specification introduces a set of user preference media features client hints headers like <code>Sec-CH-Prefers-Color-Scheme</code>, which notify the server of user preferences that will meaningfully alter the requested resource, like, for example, through the currently preferred color scheme. These client hints will commonly also be used as critical client hints via the <code>Critical-CH</code> header.
+Markup Shorthands: markdown yes
 </pre>
 
 <pre class=biblio>
@@ -47,13 +48,6 @@ Abstract: HTTP Client Hints defines an <code>Accept-CH</code> response header th
     "title": "Permissions Policy",
     "status": "ED",
     "publisher": "W3C"
-  },
-  "savedata": {
-    "authors" : ["Yoav Weiss", "Ilya Grigorik"],
-    "href": "https://wicg.github.io/savedata/#save-data-request-header-field",
-    "title": "Save Data API",
-    "status": "Draft Community Group Report",
-    "publisher": "Web Incubator Community Group"
   }
 }
 </pre>
@@ -128,7 +122,7 @@ infrastructure defined in [[!RFC8942]].
 User preference media features consist of a name (like <code>prefers-reduced-motion</code>) and allowed values
 (like <code>no-preference</code> or <code>reduce</code>. Each client hint header field defined in the following
 is represented as [[!draft-ietf-httpbis-header-structure-19]] object containing an [=items=] whose value
-is a [=string=]. The ABNF (Augmented Backus-Naur Form) for each header is given below.
+is a [=structured header value/string=]. The ABNF (Augmented Backus-Naur Form) for each header is given below.
 It is the expectation of the author that these client hints will commonly be used as
 [[!draft-davidben-http-client-hint-reliability-02]].
 


### PR DESCRIPTION
This PR fixes bikeshed link errors and warnings below:
```
LINK ERROR: Ambiguous for-less link for 'string', please see <https://tabatkins.github.io/bikeshed/#ambi-for> for instructions:
Local references:
spec:draft-ietf-httpbis-header-structure-19; type:dfn; for:structured header value; text:string
for-less references:
spec:css-values-3; type:dfn; for:/; text:string
spec:infra; type:dfn; for:/; text:string
[=string=]
LINK ERROR: No 'property' refs found for 'self'.
'self'
WARNING: The following locally-defined biblio entries are unused and can be removed:
  * SAVEDATA
 ✔ Successfully generated, with 2 linking errors
 ```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/user-preference-media-features-headers/pull/9.html" title="Last updated on Sep 15, 2022, 8:20 AM UTC (d111efc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/user-preference-media-features-headers/9/e5de0f2...d111efc.html" title="Last updated on Sep 15, 2022, 8:20 AM UTC (d111efc)">Diff</a>